### PR TITLE
Prevent task scheduling and execution on terminating nodes

### DIFF
--- a/dist/src/runtime.rs
+++ b/dist/src/runtime.rs
@@ -313,6 +313,12 @@ impl DistRuntime {
     }
 
     pub async fn receive_tasks(&self, scheduled_tasks: ScheduledTasks) -> DistResult<()> {
+        if matches!(*self.status.lock(), NodeStatus::Terminating) {
+            return Err(DistError::internal(
+                "Local node is in Terminating status, cannot receive tasks",
+            ));
+        }
+
         debug!(
             "Received job {} tasks: [{}] and plans of stages: [{}]",
             scheduled_tasks.job_id()?,

--- a/dist/src/scheduler.rs
+++ b/dist/src/scheduler.rs
@@ -78,6 +78,14 @@ impl DistScheduler for DefaultScheduler {
         node_states: &HashMap<NodeId, NodeState>,
         stage_plans: &HashMap<StageId, Arc<dyn ExecutionPlan>>,
     ) -> DistResult<HashMap<TaskId, NodeId>> {
+        if let Some(state) = node_states.get(local_node)
+            && matches!(state.status, NodeStatus::Terminating)
+        {
+            return Err(DistError::schedule(
+                "Local node is in Terminating status, cannot schedule tasks",
+            ));
+        }
+
         // Filter out nodes that are in Terminating status
         let available_nodes: HashMap<NodeId, NodeState> = node_states
             .iter()


### PR DESCRIPTION
- Add Terminating status check in scheduler
- Add Terminating status check in runtime