### PR TITLE
fix: cleanup old containers and images before integration tests

### DIFF
--- a/integration-tests/src/docker.rs
+++ b/integration-tests/src/docker.rs
@@ -80,6 +80,15 @@ impl DockerCompose {
     }
 
     pub fn up(&self) {
+        // Step 1: Stop and remove old containers
+        self.down();
+
+        // Step 2: Remove old image (ignore error if image doesn't exist)
+        let mut rmi_cmd = Command::new("docker");
+        rmi_cmd.args(vec!["rmi", "-f", "datafusion-dist-integration-tests-app"]);
+        let _ = rmi_cmd.status(); // Ignore result
+
+        // Step 3: Start containers with build
         let mut cmd = Command::new("docker");
         cmd.current_dir(&self.docker_compose_dir);
 
@@ -92,6 +101,7 @@ impl DockerCompose {
             "up",
             "-d",
             "--wait",
+            "--build",
             "--timeout",
             "1200000",
         ]);


### PR DESCRIPTION
## Summary

This PR improves the integration test setup by ensuring a clean environment before each test run.

## Changes

Modified DockerCompose::up() method in integration-tests/src/docker.rs to:

1. **Stop and remove old containers** - Call down() before starting new containers to ensure no stale containers are running

2. **Remove old image** - Delete the old image datafusion-dist-integration-tests-app before building (errors are ignored if image doesn't exist)

3. **Force image rebuild** - Added --build flag to docker compose up command to ensure the image is always rebuilt with the latest code

## Why

Previously, integration tests could use stale images from previous runs, leading to:
- Testing against outdated code
- Inconsistent test results
- Difficult-to-debug issues when code changes weren't reflected in tests

## Testing

- [x] Code compiles successfully (cargo check -p datafusion-dist-integration-tests)
- [x] Docker commands execute without errors

## Related

This fix ensures integration tests always run with the latest built image.