### PR TITLE
fix(networks/tonic): use bb8 connection pool for gRPC channels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+docs
+.worktrees

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -517,6 +517,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "bb8-tonic"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9f800a9d7c9e85dd9421474bd83c69763696539b6ee40b783fd33f38f2368cb"
+dependencies = [
+ "bb8",
+ "bytes",
+ "futures",
+ "http",
+ "tonic",
+ "tower-service",
+]
+
+[[package]]
 name = "bigdecimal"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1236,6 +1250,8 @@ dependencies = [
  "arrow-flight",
  "async-trait",
  "backon",
+ "bb8",
+ "bb8-tonic",
  "datafusion-common",
  "datafusion-dist",
  "datafusion-execution",

--- a/networks/tonic/Cargo.toml
+++ b/networks/tonic/Cargo.toml
@@ -14,6 +14,8 @@ async-trait = { workspace = true }
 arrow = { workspace = true }
 arrow-flight = { workspace = true }
 backon = { workspace = true }
+bb8 = "0.9"
+bb8-tonic = "0.4.0"
 datafusion-common = { workspace = true }
 datafusion-execution = { workspace = true }
 datafusion-physical-expr = { workspace = true }

--- a/networks/tonic/src/network.rs
+++ b/networks/tonic/src/network.rs
@@ -8,6 +8,8 @@ use arrow::datatypes::Schema;
 use arrow_flight::decode::FlightRecordBatchStream;
 use arrow_flight::error::FlightError;
 use backon::{ExponentialBuilder, Retryable};
+use bb8::Pool;
+use bb8_tonic::TonicChannelManager;
 use datafusion_common::DataFusionError;
 use datafusion_dist::{
     DistError, DistResult, JobId,
@@ -22,7 +24,7 @@ use datafusion_proto::{
     physical_plan::{AsExecutionPlan, ComposedPhysicalExtensionCodec, PhysicalExtensionCodec},
     protobuf::PhysicalPlanNode,
 };
-use futures::{StreamExt, TryStreamExt};
+use futures::{StreamExt, TryStreamExt, lock::Mutex};
 use tonic::transport::{Channel, Endpoint};
 
 use crate::{
@@ -36,6 +38,7 @@ use crate::{
 
 const DIST_RPC_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
 const DIST_RPC_TIMEOUT: Duration = Duration::from_secs(30);
+const RPC_POOL_MAX_SIZE: u32 = 4;
 const RPC_RETRY_MAX_DELAY: Duration = Duration::from_secs(10);
 const RPC_RETRY_MAX_TIMES: usize = 3;
 
@@ -50,6 +53,7 @@ fn retry_strategy() -> ExponentialBuilder {
 pub struct DistTonicNetwork {
     pub port: u16,
     pub composed_extension_codec: Arc<dyn PhysicalExtensionCodec>,
+    pools: Mutex<HashMap<NodeId, Arc<Pool<TonicChannelManager>>>>,
 }
 
 impl DistTonicNetwork {
@@ -63,6 +67,7 @@ impl DistTonicNetwork {
         Self {
             port,
             composed_extension_codec,
+            pools: Mutex::new(HashMap::new()),
         }
     }
 }
@@ -107,6 +112,56 @@ impl DistTonicNetwork {
             plan: plan_buf,
         })
     }
+
+    async fn get_or_create_pool(
+        &self,
+        node_id: &NodeId,
+    ) -> DistResult<Arc<Pool<TonicChannelManager>>> {
+        {
+            let pools = self.pools.lock().await;
+            if let Some(pool) = pools.get(node_id) {
+                return Ok(pool.clone());
+            }
+        }
+
+        let addr = format!("http://{}:{}", node_id.host, node_id.port);
+        let endpoint = Endpoint::from_shared(addr)
+            .map_err(|e| DistError::network(Box::new(e)))?
+            .connect_timeout(DIST_RPC_CONNECT_TIMEOUT)
+            .timeout(DIST_RPC_TIMEOUT);
+
+        let manager = TonicChannelManager::new_single(endpoint);
+        let pool = Pool::builder()
+            .max_size(RPC_POOL_MAX_SIZE)
+            .build(manager)
+            .await
+            .map_err(|e| DistError::network(Box::new(e)))?;
+
+        let pool = Arc::new(pool);
+
+        let mut pools = self.pools.lock().await;
+        if let Some(existing) = pools.get(node_id) {
+            return Ok(existing.clone());
+        }
+        pools.insert(node_id.clone(), pool.clone());
+
+        Ok(pool)
+    }
+
+    async fn build_tonic_client(
+        &self,
+        node_id: &NodeId,
+    ) -> DistResult<DistTonicServiceClient<Channel>> {
+        let pool = self.get_or_create_pool(node_id).await?;
+        let conn = pool
+            .get()
+            .await
+            .map_err(|e| DistError::network(Box::new(e)))?;
+        let channel = (*conn).clone();
+        Ok(DistTonicServiceClient::new(channel)
+            .max_encoding_message_size(usize::MAX)
+            .max_decoding_message_size(usize::MAX))
+    }
 }
 
 #[async_trait::async_trait]
@@ -123,7 +178,7 @@ impl DistNetwork for DistTonicNetwork {
         let send_tasks_req = self.serialize_scheduled_tasks(scheduled_tasks)?;
 
         (|| async {
-            let mut tonic_client = build_tonic_client(&node_id).await?;
+            let mut tonic_client = self.build_tonic_client(&node_id).await?;
             tonic_client
                 .send_tasks(send_tasks_req.clone())
                 .await
@@ -139,7 +194,7 @@ impl DistNetwork for DistTonicNetwork {
         node_id: NodeId,
         task_id: TaskId,
     ) -> DistResult<SendableRecordBatchStream> {
-        let mut tonic_client = build_tonic_client(&node_id).await?;
+        let mut tonic_client = self.build_tonic_client(&node_id).await?;
         let response = tonic_client
             .execute_task(serialize_task_id(task_id))
             .await
@@ -175,7 +230,7 @@ impl DistNetwork for DistTonicNetwork {
         job_id: Option<JobId>,
     ) -> DistResult<HashMap<StageId, StageInfo>> {
         (|| async {
-            let mut tonic_client = build_tonic_client(&node_id).await?;
+            let mut tonic_client = self.build_tonic_client(&node_id).await?;
             let req = protobuf::GetJobStatusReq {
                 job_id: job_id.as_ref().map(|id| id.to_string()),
             };
@@ -206,7 +261,7 @@ impl DistNetwork for DistTonicNetwork {
 
     async fn cleanup_job(&self, node_id: NodeId, job_id: JobId) -> DistResult<()> {
         (|| async {
-            let mut tonic_client = build_tonic_client(&node_id).await?;
+            let mut tonic_client = self.build_tonic_client(&node_id).await?;
             let req = protobuf::CleanupJobReq {
                 job_id: job_id.to_string(),
             };
@@ -221,29 +276,4 @@ impl DistNetwork for DistTonicNetwork {
         .retry(retry_strategy())
         .await
     }
-}
-
-async fn build_tonic_channel(node_id: &NodeId) -> DistResult<Channel> {
-    let addr = format!("http://{}:{}", node_id.host, node_id.port);
-
-    (|| async {
-        let endpoint = Endpoint::from_shared(addr.clone())
-            .map_err(|e| DistError::network(Box::new(e)))?
-            .connect_timeout(DIST_RPC_CONNECT_TIMEOUT)
-            .timeout(DIST_RPC_TIMEOUT);
-
-        endpoint
-            .connect()
-            .await
-            .map_err(|e| DistError::network(Box::new(e)))
-    })
-    .retry(retry_strategy())
-    .await
-}
-
-async fn build_tonic_client(node_id: &NodeId) -> DistResult<DistTonicServiceClient<Channel>> {
-    let channel = build_tonic_channel(node_id).await?;
-    Ok(DistTonicServiceClient::new(channel)
-        .max_encoding_message_size(usize::MAX)
-        .max_decoding_message_size(usize::MAX))
 }


### PR DESCRIPTION
  Replace per-RPC TCP connection creation with a cached bb8 pool
  per NodeId. Each pool holds up to 4 tonic Channels, eliminating
  port exhaustion and TCP handshake overhead on every request.

  Key changes:
  - Add bb8 and bb8-tonic dependencies
  - Cache bb8::Pool<TonicChannelManager> per NodeId
  - Clone Channel from pooled connection to avoid lifetime issues
  - Use futures::lock::Mutex for async-safe pool cache
  - Remove build_tonic_channel/build_tonic_client free functions