### PR TITLE
refactor(dist): optimize job completion check and event handling

### DIFF
--- a/dist/src/event.rs
+++ b/dist/src/event.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use backon::{ExponentialBuilder, Retryable};
+use futures::future::join_all;
 use log::{debug, error};
 use parking_lot::Mutex;
 use tokio::sync::mpsc::{Receiver, Sender};
@@ -82,26 +83,28 @@ impl EventHandler {
                     });
                 }
                 Event::CleanupJob(job_id) => {
-                    self.handle_cleanup_job(job_id).await;
+                    let local_node = self.local_node.clone();
+                    let cluster = self.cluster.clone();
+                    let network = self.network.clone();
+                    let local_stages = self.local_stages.clone();
+                    tokio::spawn(async move {
+                        if let Err(e) = cleanup_job(
+                            &local_node,
+                            &cluster,
+                            &network,
+                            &local_stages,
+                            job_id.clone(),
+                        )
+                        .await
+                        {
+                            error!("Failed to cleanup job {job_id}: {e}");
+                        }
+                    });
                 }
                 Event::ReceivedStage0Tasks(stage0_ids) => {
                     self.handle_received_stage0_tasks(stage0_ids).await;
                 }
             }
-        }
-    }
-
-    async fn handle_cleanup_job(&mut self, job_id: JobId) {
-        if let Err(e) = cleanup_job(
-            &self.local_node,
-            &self.cluster,
-            &self.network,
-            &self.local_stages,
-            job_id.clone(),
-        )
-        .await
-        {
-            error!("Failed to cleanup job {job_id}: {e}");
         }
     }
 
@@ -257,15 +260,22 @@ pub async fn cleanup_job(
     job_id: JobId,
 ) -> DistResult<()> {
     let alive_nodes = cluster.alive_nodes().await?;
+    let mut futures = Vec::new();
 
     for node_id in alive_nodes.keys() {
         if node_id == local_node {
             let mut guard = local_stages.lock();
             guard.retain(|stage_id, _| stage_id.job_id != job_id);
-            drop(guard);
         } else {
-            network.cleanup_job(node_id.clone(), job_id.clone()).await?
+            let network = network.clone();
+            let node_id = node_id.clone();
+            let job_id = job_id.clone();
+            futures.push(async move { network.cleanup_job(node_id, job_id).await });
         }
+    }
+
+    for res in join_all(futures).await {
+        res?;
     }
     Ok(())
 }

--- a/dist/src/event.rs
+++ b/dist/src/event.rs
@@ -66,7 +66,20 @@ impl EventHandler {
             debug!("Received event: {event:?}");
             match event {
                 Event::CheckJobCompleted(job_id) => {
-                    self.handle_check_job_completed(job_id).await;
+                    let cluster = self.cluster.clone();
+                    let network = self.network.clone();
+                    let local_stages = self.local_stages.clone();
+                    let sender = self.sender.clone();
+                    tokio::spawn(async move {
+                        handle_check_job_completed(
+                            &cluster,
+                            &network,
+                            &local_stages,
+                            &sender,
+                            job_id,
+                        )
+                        .await;
+                    });
                 }
                 Event::CleanupJob(job_id) => {
                     self.handle_cleanup_job(job_id).await;
@@ -74,34 +87,6 @@ impl EventHandler {
                 Event::ReceivedStage0Tasks(stage0_ids) => {
                     self.handle_received_stage0_tasks(stage0_ids).await;
                 }
-            }
-        }
-    }
-
-    async fn handle_check_job_completed(&mut self, job_id: JobId) {
-        match (|| async {
-            check_job_completed(
-                &self.cluster,
-                &self.network,
-                &self.local_stages,
-                job_id.clone(),
-            )
-            .await
-        })
-        .retry(job_check_retry_strategy())
-        .await
-        {
-            Ok(Some(true)) => {
-                debug!("Job {job_id} completed, remove it from cluster");
-                if let Err(e) =
-                    send_event_with_timeout(&self.sender, Event::CleanupJob(job_id.clone())).await
-                {
-                    error!("Failed to send cleanup job event for job {job_id}: {e}");
-                }
-            }
-            Ok(_) => {}
-            Err(err) => {
-                error!("Failed to check job {job_id} completed: {err}");
             }
         }
     }
@@ -153,6 +138,31 @@ impl EventHandler {
                 );
             }
         });
+    }
+}
+
+async fn handle_check_job_completed(
+    cluster: &Arc<dyn DistCluster>,
+    network: &Arc<dyn DistNetwork>,
+    local_stages: &Arc<Mutex<HashMap<StageId, StageState>>>,
+    sender: &Sender<Event>,
+    job_id: JobId,
+) {
+    match (|| async { check_job_completed(cluster, network, local_stages, job_id.clone()).await })
+        .retry(job_check_retry_strategy())
+        .await
+    {
+        Ok(Some(true)) => {
+            debug!("Job {job_id} completed, remove it from cluster");
+            if let Err(e) = send_event_with_timeout(sender, Event::CleanupJob(job_id.clone())).await
+            {
+                error!("Failed to send cleanup job event for job {job_id}: {e}");
+            }
+        }
+        Ok(_) => {}
+        Err(err) => {
+            error!("Failed to check job {job_id} completed: {err}");
+        }
     }
 }
 

--- a/dist/src/runtime.rs
+++ b/dist/src/runtime.rs
@@ -74,7 +74,7 @@ impl DistRuntime {
             status: status.clone(),
         };
 
-        let (sender, receiver) = tokio::sync::mpsc::channel::<Event>(1024);
+        let (sender, receiver) = tokio::sync::mpsc::channel::<Event>(8 * 1024);
 
         let event_handler = EventHandler {
             local_node: node_id.clone(),
@@ -457,13 +457,17 @@ impl DistRuntime {
     }
 }
 
+/// Tracks the runtime state of a single execution stage on the local node.
 #[derive(Debug)]
 pub struct StageState {
     pub stage_id: StageId,
     pub create_at_ms: i64,
     pub stage_plan: Arc<dyn ExecutionPlan>,
+    /// Partitions assigned to this local node for execution.
     pub assigned_partitions: HashSet<usize>,
+    /// Active and completed task groups for this stage on this node.
     pub task_sets: Vec<TaskSet>,
+    /// Global mapping of every task in the job to its assigned node.
     pub job_task_distribution: Arc<HashMap<TaskId, NodeId>>,
     pub job_meta: Arc<HashMap<String, String>>,
 }
@@ -524,6 +528,11 @@ impl StageState {
         self.assigned_partitions
             .difference(&executed_partitions)
             .count()
+    }
+
+    /// Returns true if all tasks assigned to this stage on the local node have completed.
+    pub fn all_assigned_partitions_completed(&self) -> bool {
+        self.num_running_tasks() == 0 && self.num_pending_tasks() == 0
     }
 
     pub fn get_plan(&mut self, partition: usize) -> DistResult<(Uuid, Arc<dyn ExecutionPlan>)> {
@@ -689,34 +698,24 @@ impl Drop for TaskStream {
         };
         debug!("Task {task_id} dropped with metrics: {task_metrics:?}");
 
-        let stages = self.stages.clone();
-        let sender = self.event_sender.clone();
-        tokio::spawn(async move {
-            let mut send_event = false;
-            {
-                let mut guard = stages.lock();
-                if let Some(stage_state) = guard.get_mut(&task_id.stage_id()) {
-                    stage_state.complete_task(task_id.clone(), task_set_id, task_metrics);
-                    if stage_state.stage_id.stage == 0
-                        && stage_state.assigned_partitions_executed_at_least_once()
-                    {
-                        send_event = true;
-                    }
-                }
+        let should_send = {
+            let mut guard = self.stages.lock();
+            if let Some(stage_state) = guard.get_mut(&task_id.stage_id()) {
+                stage_state.complete_task(task_id.clone(), task_set_id, task_metrics);
+                stage_state.stage_id.stage == 0 && stage_state.all_assigned_partitions_completed()
+            } else {
+                false
             }
+        };
 
-            if send_event
-                && let Err(e) = send_event_with_timeout(
-                    &sender,
-                    Event::CheckJobCompleted(task_id.job_id.clone()),
-                )
-                .await
-            {
+        if should_send {
+            let event = Event::CheckJobCompleted(task_id.job_id.clone());
+            if let Err(e) = self.event_sender.try_send(event) {
                 error!(
                     "Failed to send CheckJobCompleted event after task {task_id} stream dropped: {e}"
                 );
             }
-        });
+        }
     }
 }
 


### PR DESCRIPTION
- Spawn handle_check_job_completed to avoid blocking event loop
- Make TaskStream::drop synchronous instead of spawning async task
- Use try_send for CheckJobCompleted in drop context
- Increase event channel capacity from 1024 to 8192
- Add StageState docs and all_assigned_partitions_completed helper