### PR TITLE
test(dist): add regression tests for empty projection RecordBatch row_count preservation

### DIFF
--- a/integration-tests/tests/sqllogictest.slt
+++ b/integration-tests/tests/sqllogictest.slt
@@ -69,3 +69,20 @@ select * from (select *,rank() over(partition by id order by view_updated desc n
 1 latest 200 1
 2 only_null NULL 1
 3 latest3 50 1
+
+# COUNT(*) aggregation through dist path
+query I
+select count(*) from simple
+----
+2
+
+query I
+select count(*) from "public"."file_grid_original_44691_20260313152925290"
+----
+6
+
+# COUNT(*) with empty result set through dist path
+query I
+select count(*) from simple where name = 'nonexistent'
+----
+0


### PR DESCRIPTION
## Summary

Add sqllogictest integration tests to cover COUNT(*) aggregation through the datafusion-dist distributed execution path.

## What this PR covers

This PR is **sqllogictest regression coverage**, ensuring COUNT aggregation works correctly through the dist integration path. It adds 3 SQL-level assertions to `integration-tests/tests/sqllogictest.slt`:

1. `select count(*) from simple` — verifies COUNT(*) on 2-row table returns 2
2. `select count(*) from file_grid_original_44691_...` — verifies COUNT(*) on 6-row table returns 6
3. `select count(*) from simple where name = 'nonexistent'` — verifies COUNT(*) returns 0 for empty result set

## What this PR does NOT cover

The empty projection (`projection: Some(&[])`) scenario that triggered the data-fabric `kafka_jobs COUNT(*)` panic **cannot be reproduced** via standard SQL + `MemTable`, because DataFusion's optimizer does not push empty projections down to `MemorySourceConfig`. Reproducing the exact `0-column + N-rows` batch behavior requires a custom TableProvider, which is **out of scope for this PR**.

## Test Command

```bash
cd integration-tests
cargo test sqllogictest
```

## Local Validation Status

- WSL2 environment: Docker available, but `docker-compose` is not installed.
- Full sqllogictest suite could not be run locally; awaiting CI or an environment with docker-compose.

## Scope

- No production logic changes.
- Only modifies `integration-tests/tests/sqllogictest.slt`.