### PR TITLE
test(integration-tests): draft / regression repro — 0-column RecordBatch via custom TableProvider

### DIFF
--- a/integration-tests/src/data.rs
+++ b/integration-tests/src/data.rs
@@ -1,16 +1,27 @@
-use std::sync::Arc;
+use std::{any::Any, sync::Arc};
 
+use async_trait::async_trait;
 use datafusion::{
     arrow::{
         array::{Int32Array, Int64Array, StringArray},
-        datatypes::{DataType, Field, Schema},
-        record_batch::RecordBatch,
+        datatypes::{DataType, Field, Schema, SchemaRef},
+        record_batch::{RecordBatch, RecordBatchOptions},
     },
+    catalog::Session,
     common::Result as DFResult,
-    datasource::MemTable,
+    datasource::{MemTable, TableProvider, TableType},
+    error::DataFusionError,
+    execution::{SendableRecordBatchStream, TaskContext},
     logical_expr::{ColumnarValue, Volatility},
-    prelude::{SessionConfig, SessionContext, create_udf},
+    physical_expr::EquivalenceProperties,
+    physical_plan::{
+        DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties,
+        execution_plan::{Boundedness, EmissionType},
+        stream::RecordBatchStreamAdapter,
+    },
+    prelude::{Expr, SessionConfig, SessionContext, create_udf},
 };
+use futures::stream;
 
 pub fn build_session_context() -> SessionContext {
     let config = SessionConfig::new().with_target_partitions(12).set_bool(
@@ -26,6 +37,7 @@ pub fn build_session_context() -> SessionContext {
 pub fn register_tables(ctx: &SessionContext) {
     register_simple_table(ctx);
     register_file_grid_original_44691_table(ctx);
+    register_zero_col_tables(ctx);
 }
 
 pub fn register_udfs(ctx: &SessionContext) {
@@ -155,4 +167,182 @@ fn cpu_intensive_udf_impl(args: &[ColumnarValue]) -> DFResult<ColumnarValue> {
             Ok(ColumnarValue::Array(Arc::new(arr)))
         }
     }
+}
+
+// ============================================================
+// Zero-column RecordBatch regression fixture
+// ------------------------------------------------------------
+// `ZeroColTable` is a custom [`TableProvider`] that **intentionally does NOT
+// normalize** `projection = Some(empty)` to `Some(vec![0])`. This mirrors the
+// pre-fix shape of the custom TableProviders in `data-fabric` which paniced
+// in the dist path when `COUNT(*)` lowered the projection to an empty vec
+// and the resulting 0-column / row_count > 0 RecordBatch flowed through
+// dist's task driver (small-table) and arrow-select coalesce (repartition).
+//
+// The fix in data-fabric (`normalize_projection()`, commit `6e7b30a3`) is
+// purely on the TableProvider side. This fixture exists so that the dist
+// integration suite can act as a regression guard for the dist-side
+// behavior under 0-column batches with `row_count > 0` — i.e. so that any
+// future change to dist that re-introduces a panic on this shape is caught
+// here, regardless of whether upstream TableProvider authors remember to
+// normalize their projections.
+//
+// The two registered variants exist to cover both code paths that have
+// historically paniced:
+//
+//   * `zero_col_small` — 1 partition, 2 rows. Targets the small-table /
+//     single-task path (e.g. `dist/src/util.rs` `assert_eq!` on column
+//     counts when consolidating partial aggregates).
+//   * `zero_col_large` — 4 partitions, 2 rows each (8 rows total). Forces
+//     repartition through `RepartitionExec` / `CoalescePartitionsExec`,
+//     which has historically paniced at `arrow-select coalesce.rs:462`
+//     when feeding 0-column batches into the coalesce buffer.
+//
+// Both tables are registered unconditionally — they are inert unless
+// queried. Queries that exercise them live in
+// `tests/zero_col_regression.slt`, run only by the `#[ignore]` /
+// env-gated test in `tests/sqllogictest.rs` so the default `cargo test`
+// run does not turn main CI red.
+// ============================================================
+
+#[derive(Debug, Clone)]
+pub struct ZeroColTable {
+    schema: SchemaRef,
+    rows_per_partition: usize,
+    num_partitions: usize,
+}
+
+impl ZeroColTable {
+    pub fn new(rows_per_partition: usize, num_partitions: usize) -> Self {
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        Self {
+            schema,
+            rows_per_partition,
+            num_partitions,
+        }
+    }
+}
+
+#[async_trait]
+impl TableProvider for ZeroColTable {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::Base
+    }
+
+    async fn scan(
+        &self,
+        _state: &dyn Session,
+        projection: Option<&Vec<usize>>,
+        _filters: &[Expr],
+        _limit: Option<usize>,
+    ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        // INTENTIONAL: do NOT normalize `Some(empty)` → `Some(vec![0])`.
+        // This reproduces the pre-fix behavior of data-fabric task #7/#10.
+        let projected_schema: SchemaRef = match projection {
+            None => self.schema.clone(),
+            Some(p) if p.is_empty() => Arc::new(Schema::empty()),
+            Some(p) => Arc::new(self.schema.project(p)?),
+        };
+        let cache = PlanProperties::new(
+            EquivalenceProperties::new(projected_schema.clone()),
+            Partitioning::UnknownPartitioning(self.num_partitions),
+            EmissionType::Incremental,
+            Boundedness::Bounded,
+        );
+        Ok(Arc::new(ZeroColExec {
+            projected_schema,
+            rows_per_partition: self.rows_per_partition,
+            num_partitions: self.num_partitions,
+            cache,
+        }))
+    }
+}
+
+#[derive(Debug)]
+struct ZeroColExec {
+    projected_schema: SchemaRef,
+    rows_per_partition: usize,
+    num_partitions: usize,
+    cache: PlanProperties,
+}
+
+impl ExecutionPlan for ZeroColExec {
+    fn name(&self) -> &str {
+        "ZeroColExec"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn properties(&self) -> &PlanProperties {
+        &self.cache
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        _children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
+        Ok(self)
+    }
+
+    fn execute(
+        &self,
+        _partition: usize,
+        _context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream, DataFusionError> {
+        let schema = self.projected_schema.clone();
+        let rows = self.rows_per_partition;
+        let batch = if schema.fields().is_empty() {
+            // 0-column RecordBatch with `row_count > 0` — the exact shape
+            // that paniced dist's util.rs:113 and arrow-select coalesce.
+            RecordBatch::try_new_with_options(
+                schema.clone(),
+                vec![],
+                &RecordBatchOptions::new().with_row_count(Some(rows)),
+            )?
+        } else {
+            // Normal id batch when the planner asked for the `id` column.
+            let ids: Vec<i32> = (0..rows as i32).collect();
+            RecordBatch::try_new(schema.clone(), vec![Arc::new(Int32Array::from(ids))])?
+        };
+        let stream = stream::iter(std::iter::once(Ok(batch)));
+        Ok(Box::pin(RecordBatchStreamAdapter::new(schema, stream)))
+    }
+}
+
+impl DisplayAs for ZeroColExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "ZeroColExec: schema_fields={}, rows_per_partition={}, partitions={}",
+            self.projected_schema.fields().len(),
+            self.rows_per_partition,
+            self.num_partitions,
+        )
+    }
+}
+
+pub fn register_zero_col_tables(ctx: &SessionContext) {
+    // Single-partition / small-table path.
+    let small = ZeroColTable::new(2, 1);
+    ctx.register_table("zero_col_small", Arc::new(small))
+        .expect("Failed to register zero_col_small table");
+
+    // Multi-partition path — drives repartition / coalesce stages.
+    let large = ZeroColTable::new(2, 4);
+    ctx.register_table("zero_col_large", Arc::new(large))
+        .expect("Failed to register zero_col_large table");
 }

--- a/integration-tests/tests/sqllogictest.rs
+++ b/integration-tests/tests/sqllogictest.rs
@@ -22,3 +22,49 @@ async fn sqllogictest() -> Result<(), Box<dyn std::error::Error>> {
 
     Ok(())
 }
+
+/// 0-column RecordBatch regression test (follow-up to datafabric task #7/#10).
+///
+/// This is intentionally `#[ignore]`'d: the cases in
+/// `tests/zero_col_regression.slt` deliberately drive a 0-column /
+/// row_count > 0 batch through the dist execution path, which has
+/// historically paniced (`dist/src/util.rs:113` for the small-table path
+/// and `arrow-select coalesce.rs:462` for the repartition path). The
+/// `data-fabric` fix was on the TableProvider side (`normalize_projection()`,
+/// commit `6e7b30a3`); the dist side still needs its own regression guard,
+/// but until dist can handle this shape stably we don't want this test to
+/// turn main CI red.
+///
+/// Run explicitly with:
+/// ```sh
+/// cargo test -p datafusion-dist-integration-tests --test sqllogictest \
+///   -- --ignored sqllogictest_zero_col_regression
+/// ```
+///
+/// Or via env-gate alongside the normal run:
+/// ```sh
+/// SLT_RUN_ZERO_COL=1 cargo test -p datafusion-dist-integration-tests \
+///   --test sqllogictest -- --include-ignored
+/// ```
+#[tokio::test]
+#[ignore = "regression repro for 0-col batch — runs only on demand to keep main CI green"]
+async fn sqllogictest_zero_col_regression() -> Result<(), Box<dyn std::error::Error>> {
+    setup_containers().await;
+
+    let mut tester = sqllogictest::Runner::new(|| async {
+        FlightSqlDB::new_from_endpoint("dist", "http://localhost:50061", "admin", "admin123").await
+    });
+    tester.with_column_validator(sqllogictest::strict_column_validator);
+
+    tester
+        .run_file_async("tests/zero_col_regression.slt")
+        .await?;
+
+    tokio::time::sleep(Duration::from_secs(5)).await;
+
+    // all jobs should be cleaned up — same invariant as the main suite.
+    let batches = execute_flightsql_query("select * from running_jobs").await?;
+    assert!(batches.is_empty());
+
+    Ok(())
+}

--- a/integration-tests/tests/zero_col_regression.slt
+++ b/integration-tests/tests/zero_col_regression.slt
@@ -1,0 +1,99 @@
+# ============================================================
+# Zero-column RecordBatch regression — datafabric task #7/#10 follow-up
+# ------------------------------------------------------------
+# Fixture lives in `integration-tests/src/data.rs`:
+#
+#   - `zero_col_small` — 1 partition, 2 rows. Drives the small-table /
+#     single-task code path (historically: `dist/src/util.rs:113`
+#     assert_eq! on column counts when consolidating partial aggregates).
+#
+#   - `zero_col_large` — 4 partitions × 2 rows = 8 rows. Drives the
+#     repartition / coalesce path (historically: `arrow-select
+#     coalesce.rs:462` assert_eq! when feeding 0-column batches through
+#     `RepartitionExec` / `CoalescePartitionsExec`).
+#
+# Both tables deliberately leave `projection = Some(empty)` unnormalized
+# in `scan()`, so `SELECT COUNT(*)` against them emits a
+# 0-column / `row_count > 0` RecordBatch into the dist execution path.
+# This is the exact shape that the data-fabric fix `normalize_projection()`
+# (commit `6e7b30a3`) papered over on the TableProvider side. Running
+# these queries against dist is the regression guard for the dist side.
+#
+# These cases are gated and DO NOT run as part of the default
+# `cargo test` — see `tests/sqllogictest.rs` for the `#[ignore]` /
+# env-gated runner. Run with:
+#   `cargo test -p datafusion-dist-integration-tests \
+#      --test sqllogictest -- --ignored sqllogictest_zero_col_regression`
+# ============================================================
+
+# ------------------------------------------------------------
+# Small / single-partition path
+# ------------------------------------------------------------
+
+# COUNT(*) — lowers to `projection = Some(vec![])` in the optimizer,
+# which our custom provider leaves untouched. Expected: 2 rows.
+query I
+select count(*) from zero_col_small
+----
+2
+
+# SELECT * — projection `None`. Normal id column path, regression
+# sanity check that the provider can also serve a non-empty projection.
+query I rowsort
+select * from zero_col_small
+----
+0
+1
+
+# COUNT(*) with always-false WHERE — empty result through the same
+# empty-projection lowering.
+query I
+select count(*) from zero_col_small where id < 0
+----
+0
+
+# ------------------------------------------------------------
+# Multi-partition / repartition path
+# ------------------------------------------------------------
+
+# COUNT(*) across 4 partitions — partial aggregates each emit a
+# 0-column / row_count > 0 batch and then have to be re-shuffled and
+# coalesced through dist before the final aggregate runs.
+query I
+select count(*) from zero_col_large
+----
+8
+
+# Force hash join `Partitioned` mode so the planner re-partitions both
+# inputs even at small cardinalities. This puts the 0-column scan
+# upstream of an explicit `RepartitionExec` that goes through
+# `arrow-select coalesce`.
+statement ok
+set datafusion.optimizer.hash_join_single_partition_threshold = 0;
+
+statement ok
+set datafusion.optimizer.hash_join_single_partition_threshold_rows = 0;
+
+# COUNT(*) of a partitioned hash join over the zero-col fixture — the
+# repartition before the join consumes the 0-column scan stream.
+query I
+select count(*) from zero_col_large as a join zero_col_large as b on a.id = b.id
+----
+8
+
+# Restore defaults for any later cases.
+statement ok
+set datafusion.optimizer.hash_join_single_partition_threshold = 1048576;
+
+statement ok
+set datafusion.optimizer.hash_join_single_partition_threshold_rows = 131072;
+
+# ------------------------------------------------------------
+# Cross-table sanity — confirms that a zero-col scan being one
+# leg of a query doesn't poison adjacent batches from MemTable.
+# ------------------------------------------------------------
+
+query II
+select (select count(*) from zero_col_small) as zc, (select count(*) from simple) as s
+----
+2 2


### PR DESCRIPTION
## Status

**Draft / regression repro — not asking for merge yet.**

This PR adds a reproducer / regression-guard fixture for the 0-column
`RecordBatch` boundary that paniced data-fabric's dist execution path
(data-fabric task #7/#10). The fix in data-fabric was on the
`TableProvider` side (`normalize_projection()`, commit `6e7b30a3`);
this PR adds a regression guard on the dist side so that future dist
changes can't silently regress on this shape regardless of upstream
`TableProvider` hygiene.

The new test is gated `#[ignore]` so default `cargo test` skips it and
**main CI stays green**. If dist already handles the 0-col batch shape
stably, we can later drop the gate and treat this as a normal PR; if it
panics, the failure stack is reproducible here as a regression artifact.

## What this PR adds

1. **`ZeroColTable` / `ZeroColExec`** in `integration-tests/src/data.rs`.
   - A custom `TableProvider` that **intentionally does NOT normalize**
     `projection = Some(empty)` to `Some(vec![0])`.
   - Two variants are registered on the dist server's session context:
     - `zero_col_small` — 1 partition / 2 rows. Drives the small-table /
       single-task code path (historically: `dist/src/util.rs:113`
       `assert_eq!` on column counts when consolidating partial
       aggregates).
     - `zero_col_large` — 4 partitions × 2 rows = 8 rows total. Drives
       the repartition / coalesce path (historically: `arrow-select
       coalesce.rs:462` `assert_eq!` when feeding 0-column batches
       through `RepartitionExec` / `CoalescePartitionsExec`).

2. **`integration-tests/tests/zero_col_regression.slt`** — exercises
   both fixtures via:
   - `COUNT(*)` on each table (the lowering that emits
     `projection = Some(vec![])`).
   - `SELECT *` sanity check (non-empty projection through the same
     provider).
   - `COUNT(*) WHERE` always-false (empty result through empty
     projection).
   - `COUNT(*)` over a `Partitioned`-mode hash join on `zero_col_large`
     to force a `RepartitionExec` above the 0-col scan stream.
   - A cross-table scalar subquery to confirm 0-col emit doesn't poison
     adjacent MemTable batches.

3. **A separate gated runner** `sqllogictest_zero_col_regression` in
   `integration-tests/tests/sqllogictest.rs`, marked `#[ignore]` and
   documented with run instructions. The main `sqllogictest` test is
   unchanged.

## Repro instructions

```sh
# Default cargo test — the new file does NOT run.
cargo test -p datafusion-dist-integration-tests --test sqllogictest

# Run only the new regression test.
cargo test -p datafusion-dist-integration-tests --test sqllogictest \
  -- --ignored sqllogictest_zero_col_regression
```

## Local validation status — needs a `docker compose`-capable environment

**Code is verified clean**, but the test has **not yet been observed
end-to-end** from the machine that authored this PR.

What was verified locally:

- `cargo check -p datafusion-dist-integration-tests --tests` — clean.
- `cargo clippy --workspace --tests -- -D warnings` — clean.
- `cargo fmt --check` — clean.
- `cargo test -p datafusion-dist-integration-tests --test sqllogictest`
  (default suite, without `--ignored`) compiles and the unchanged
  `sqllogictest` test still runs.

What is blocked here:

The integration-tests harness uses Docker Compose v2 (`docker compose
-p ... up/down`) inside `integration-tests/src/docker.rs` to bring up
the dist server / postgres / etc. The authoring environment is a WSL
distro where:

- `docker compose` (v2 plugin) is not installed.
- Docker Desktop's `docker-compose` (v1) WSL integration is not
  enabled in this distro.

As a result, `setup_containers()` immediately fails at the
`down -v --remove-orphans` precondition with:

```
unknown shorthand flag: 'p' in -p

thread 'sqllogictest_zero_col_regression' panicked at
  integration-tests/src/docker.rs:10:9:
Stopping docker compose in .../integration-tests, project name:
integration-tests-containers failed: ExitStatus(unix_wait_status(32000))
```

**This is an environment gap, not a dist-side panic.** It would block
the existing `sqllogictest` test in exactly the same way; it is not
specific to the new fixture.

### What needs to happen next

Someone with a `docker compose`-capable environment (any of: Linux box
with the `docker-compose-plugin` package, macOS with Docker Desktop,
WSL with Docker Desktop's WSL integration enabled, or the project's CI
runners) needs to run **exactly**:

```sh
cargo test -p datafusion-dist-integration-tests --test sqllogictest \
  -- --ignored sqllogictest_zero_col_regression
```

and post the outcome on this PR. Based on that outcome we then decide:

- **Pass** → drop `#[ignore]` in a follow-up commit, mark this PR as a
  normal regression-guard, ready for review.
- **Panic / fail** → keep the gate, paste the failure stack here, and
  open a separate dist-side implementation fix task; this PR stays as
  the reproducer artifact for that fix.

## Why this can't be done with a `MemTable` fixture

DataFusion's built-in `MemoryExec` / `DataSourceExec` paths already
normalize `projection = Some(empty)` via `with_row_count` internally —
they never emit a true 0-column batch into downstream stages. The
five `count(*)` cases that landed in #63 all run against `MemTable` and
therefore **do not exercise** the dist 0-col path. A custom
`TableProvider` that mirrors the data-fabric pre-fix shape is the only
way to repro the boundary inside this repo.

## Outcome interpretation

- **If the new test passes**: dist handles the shape stably today.
  Flip the gate (remove `#[ignore]`) in a follow-up commit and treat
  this as a normal regression-guard PR.
- **If the new test panics**: the failure stack and panic site (most
  likely `dist/src/util.rs:113` or `arrow-select coalesce.rs:462`) is
  the actionable artifact for a dist-side fix. The draft stays draft
  until the dist-side fix lands.

## Out of scope

- The `data-fabric` `normalize_projection()` fix is upstream of dist
  and is not modified or assumed here. Dist's regression guard must be
  independent of upstream `TableProvider` hygiene.
- Outer-join unmatched-emit (issue #64) — separate investigation.
- The indexlake `check_insert_batch_field` `is_nullable` mismatch
  (separate thread / separate task) — kept independent per review
  guidance.

## References

- data-fabric fix: `normalize_projection()` commit `6e7b30a3`
- panic sites historically observed: `dist/src/util.rs:113`,
  `arrow-select coalesce.rs:462`
- PR #63 (extended sqllogictest dist coverage, merged): provided the
  general slt scaffolding this builds on.
