### PR TITLE
fix: recursively reset plan state to avoid RepartitionExec panic on multi-endpoint fetch

### DIFF
--- a/dist/src/runtime.rs
+++ b/dist/src/runtime.rs
@@ -432,6 +432,29 @@ pub struct StageState {
     pub job_meta: Arc<HashMap<String, String>>,
 }
 
+/// Recursively reset the state of a physical plan tree.
+///
+/// DataFusion's default `reset_state()` only resets the top-level node
+/// and clones children via `with_new_children()`, which does NOT recursively
+/// reset children's internal state. This can cause issues when the same
+/// plan tree is executed multiple times (e.g., multiple Flight endpoints
+/// fetching from the same distributed stage), because stateful operators
+/// like `RepartitionExec` retain consumed state across executions.
+///
+/// This function ensures every node in the plan tree gets its state reset.
+pub fn deep_reset_state(plan: Arc<dyn ExecutionPlan>) -> datafusion_common::Result<Arc<dyn ExecutionPlan>> {
+    // First reset operator-specific state on the current node
+    let reset_plan = plan.reset_state()?;
+    // Then recursively deep-reset children
+    let children: Vec<_> = reset_plan
+        .children()
+        .into_iter()
+        .map(|c| deep_reset_state(Arc::clone(c)))
+        .collect::<datafusion_common::Result<Vec<_>>>()?;
+    // Reattach deep-reset children
+    reset_plan.with_new_children(children)
+}
+
 impl StageState {
     pub fn from_scheduled_tasks(
         scheduled_tasks: ScheduledTasks,
@@ -513,7 +536,8 @@ impl StageState {
         let task_set_id = Uuid::new_v4();
         let new_task_set = TaskSet {
             id: task_set_id,
-            shared_plan: self.stage_plan.clone().reset_state()?,
+            shared_plan: deep_reset_state(self.stage_plan.clone())
+                .map_err(|e| DistError::internal(format!("Failed to deep reset plan state: {e}")))?,
             running_partitions: HashMap::new(),
             dropped_partitions: HashMap::new(),
         };

--- a/integration-tests/src/data.rs
+++ b/integration-tests/src/data.rs
@@ -25,6 +25,7 @@ pub fn build_session_context() -> SessionContext {
 
 pub fn register_tables(ctx: &SessionContext) {
     register_simple_table(ctx);
+    register_single_partition_table(ctx);
     register_file_grid_original_44691_table(ctx);
 }
 
@@ -54,6 +55,26 @@ pub fn register_simple_table(ctx: &SessionContext) {
 
     ctx.register_table("simple", Arc::new(table))
         .expect("Failed to register simple table");
+}
+
+/// Register a single-partition table to test RepartitionExec with
+/// input_partitions=1 and multiple output partitions.
+pub fn register_single_partition_table(ctx: &SessionContext) {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("name", DataType::Utf8, false),
+        Field::new("age", DataType::Int32, false),
+    ]));
+
+    let names = StringArray::from(vec!["Alice", "Bob", "Charlie"]);
+    let ages = Int32Array::from(vec![25, 30, 35]);
+    let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(names), Arc::new(ages)])
+        .expect("Failed to create record batch");
+
+    let table = MemTable::try_new(schema, vec![vec![batch]])
+        .expect("Failed to create single-partition MemTable");
+
+    ctx.register_table("single_partition", Arc::new(table))
+        .expect("Failed to register single_partition table");
 }
 
 pub fn register_file_grid_original_44691_table(ctx: &SessionContext) {

--- a/integration-tests/tests/exception.rs
+++ b/integration-tests/tests/exception.rs
@@ -3,11 +3,13 @@ use std::{
     time::Duration,
 };
 
+use arrow::array::RecordBatch;
 use arrow_flight::sql::client::FlightSqlServiceClient;
 use datafusion_dist_integration_tests::{
     setup_containers,
     utils::{execute_flightsql_query, healthy_check_all_nodes},
 };
+use futures::TryStreamExt;
 use tonic::transport::Endpoint;
 
 #[tokio::test]
@@ -114,5 +116,52 @@ async fn cpu_intensive_task() -> Result<(), Box<dyn std::error::Error>> {
     health_thread_join_handle.join().unwrap().unwrap();
     cpu_thread_join_handle.join().unwrap().unwrap();
 
+    Ok(())
+}
+
+/// Test that fetching multiple endpoints sequentially from the same FlightInfo
+/// does not panic when the plan contains RepartitionExec with fewer input
+/// partitions than output partitions.
+///
+/// Regression test for: RepartitionExec "partition not used yet" panic
+/// when `reset_state()` does not recursively reset children's state.
+#[tokio::test]
+async fn multi_endpoint_repartition_reset_state() -> Result<(), Box<dyn std::error::Error>> {
+    setup_containers().await;
+
+    let endpoint = Endpoint::from_static("http://localhost:50061");
+    let channel = endpoint.connect().await?;
+    let mut flight_sql_client = FlightSqlServiceClient::new(channel);
+    flight_sql_client.handshake("admin", "admin123").await?;
+
+    // Force partitioned hash join to create RepartitionExec with
+    // input_partitions=1 (single_partition table) and output_partitions=12
+    let sql = "SELECT * FROM single_partition AS t1 JOIN single_partition AS t2 ON t1.name = t2.name";
+    let flight_info = flight_sql_client.execute(sql.to_string(), None).await?;
+
+    assert!(
+        flight_info.endpoint.len() > 1,
+        "Expected multiple endpoints, got {}",
+        flight_info.endpoint.len()
+    );
+    println!("FlightInfo has {} endpoints", flight_info.endpoint.len());
+
+    // Fetch endpoints sequentially (not concurrently) to verify that
+    // each endpoint can be consumed independently without state reuse panic.
+    let mut total_rows = 0;
+    for (i, ep) in flight_info.endpoint.iter().enumerate() {
+        let ticket = ep
+            .ticket
+            .as_ref()
+            .expect("ticket is required")
+            .clone();
+        let stream = flight_sql_client.do_get(ticket).await?;
+        let batches: Vec<RecordBatch> = stream.try_collect().await?;
+        let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+        println!("Endpoint {}: {} rows", i, rows);
+        total_rows += rows;
+    }
+
+    println!("Total rows across all endpoints: {}", total_rows);
     Ok(())
 }


### PR DESCRIPTION
## Problem

DataFusion's default `reset_state()` only resets the top-level node
and clones children via `with_new_children()`, which does NOT recursively
reset children's internal state. This causes `RepartitionExec` to retain
consumed state (channels) across multiple executions of the same
distributed stage plan, leading to 'partition not used yet' panic when
multiple Flight endpoints are fetched from the same job.

## Fix

Adds `deep_reset_state()` which recursively calls `reset_state()`
on every node in the plan tree before reattaching deep-reset children
via `with_new_children()`.

## Test

Adds an integration test with a single-partition table and hash
join to reproduce the multi-endpoint RepartitionExec panic scenario.

Based on commit b3947c0 (compatible with DataFusion 52).