### PR TITLE
Add stress test cases to sqllogictest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1445,6 +1445,7 @@ dependencies = [
  "log",
  "sysinfo",
  "thiserror",
+ "tokio",
  "uuid",
 ]
 

--- a/clusters/postgres/Cargo.toml
+++ b/clusters/postgres/Cargo.toml
@@ -19,3 +19,6 @@ log.workspace = true
 bb8 = "0.9"
 bb8-postgres = "0.9"
 thiserror = "2.0.17"
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt", "macros"] }

--- a/clusters/postgres/src/builder.rs
+++ b/clusters/postgres/src/builder.rs
@@ -49,7 +49,7 @@ impl PostgresClusterBuilder {
             .port(self.port)
             .user(&self.user)
             .password(&self.password);
-        if let Some(dbname) = self.dbname {
+        if let Some(ref dbname) = self.dbname {
             config.dbname(dbname);
         }
         let manager = PostgresConnectionManager::new(config, NoTls);
@@ -59,7 +59,15 @@ impl PostgresClusterBuilder {
             .idle_timeout(self.pool_idle_timeout)
             .build(manager)
             .await
-            .map_err(|e| DistError::cluster(Box::new(PostgresClusterError::Connection(e))))?;
+            .map_err(|e| {
+                DistError::cluster(Box::new(PostgresClusterError::Connection {
+                    source: e,
+                    host: self.host.clone(),
+                    port: self.port,
+                    user: self.user.clone(),
+                    db_name: self.dbname.clone().unwrap_or_else(|| "(none)".to_string()),
+                }))
+            })?;
 
         let cluster = PostgresCluster {
             table: self.table,

--- a/clusters/postgres/src/error.rs
+++ b/clusters/postgres/src/error.rs
@@ -4,14 +4,90 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum PostgresClusterError {
-    #[error("PostgreSQL connection error: {0}")]
-    Connection(#[from] PgError),
+    #[error("PostgreSQL connection error to {host}:{port} (user={user}, db={db_name}): {source}")]
+    Connection {
+        source: PgError,
+        host: String,
+        port: u16,
+        user: String,
+        db_name: String,
+    },
 
     #[error("Connection pool error: {0}")]
     Pool(#[from] bb8::RunError<PgError>),
 
     #[error("Cluster query error: {0}")]
     Query(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bb8_postgres::tokio_postgres::{self, NoTls};
+
+    #[tokio::test]
+    async fn test_connection_error_formatting() {
+        // Obtain a real PgError by connecting to a non-existent server.
+        let pg_err = match tokio_postgres::connect(
+            "host=nonexistent port=9999 user=test dbname=test",
+            NoTls,
+        )
+        .await
+        {
+            Err(e) => e,
+            Ok(_) => panic!("expected connection to fail"),
+        };
+
+        let err = PostgresClusterError::Connection {
+            source: pg_err,
+            host: "192.168.0.221".to_string(),
+            port: 33459,
+            user: "admin".to_string(),
+            db_name: "datafabric".to_string(),
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("192.168.0.221:33459"),
+            "should contain host:port, got: {}",
+            msg
+        );
+        assert!(msg.contains("user=admin"), "should contain user, got: {}", msg);
+        assert!(
+            msg.contains("db=datafabric"),
+            "should contain db, got: {}",
+            msg
+        );
+        // The source error should also appear in the output.
+        assert!(!msg.is_empty(), "error message should not be empty");
+    }
+
+    #[tokio::test]
+    async fn test_connection_error_formatting_no_db() {
+        let pg_err = match tokio_postgres::connect(
+            "host=nonexistent port=9999 user=test dbname=test",
+            NoTls,
+        )
+        .await
+        {
+            Err(e) => e,
+            Ok(_) => panic!("expected connection to fail"),
+        };
+
+        let err = PostgresClusterError::Connection {
+            source: pg_err,
+            host: "localhost".to_string(),
+            port: 5432,
+            user: "postgres".to_string(),
+            db_name: "(none)".to_string(),
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("localhost:5432"),
+            "should contain host:port, got: {}",
+            msg
+        );
+        assert!(msg.contains("db=(none)"), "should contain (none) db, got: {}", msg);
+    }
 }
 
 impl From<PostgresClusterError> for DistError {

--- a/integration-tests/tests/sqllogictest.rs
+++ b/integration-tests/tests/sqllogictest.rs
@@ -22,3 +22,62 @@ async fn sqllogictest() -> Result<(), Box<dyn std::error::Error>> {
 
     Ok(())
 }
+
+/// Stress test: execute multiple SQL queries concurrently
+/// Each query must complete successfully without errors
+#[tokio::test]
+async fn concurrent_queries_stress_test() -> Result<(), Box<dyn std::error::Error>> {
+    setup_containers().await;
+
+    // Define multiple SQL queries that exercise different execution paths
+    let queries = vec![
+        // Aggregation queries
+        "select id, count(*), sum(view_updated) from \"public\".\"file_grid_original_44691_20260313152925290\" group by id order by id",
+        "select count(*) from \"public\".\"file_grid_original_44691_20260313152925290\"",
+        "select max(view_updated), min(view_updated) from \"public\".\"file_grid_original_44691_20260313152925290\"",
+
+        // Join queries
+        "select t1.id, t2.id from \"public\".\"file_grid_original_44691_20260313152925290\" t1 join \"public\".\"file_grid_original_44691_20260313152925290\" t2 on t1.id = t2.id limit 10",
+        "select * from simple as t1 join simple as t2 on t1.age > t2.age",
+
+        // Window function queries
+        "select id, rank() over (partition by id order by view_updated desc nulls last) from \"public\".\"file_grid_original_44691_20260313152925290\"",
+
+        // Subquery with aggregation
+        "select max(cnt) from (select id, count(*) as cnt from \"public\".\"file_grid_original_44691_20260313152925290\" group by id) sub",
+
+        // UNION ALL with aggregation
+        "select id, count(*) from (select id from \"public\".\"file_grid_original_44691_20260313152925290\" union all select id from \"public\".\"file_grid_original_44691_20260313152925290\") t group by id",
+
+        // ORDER BY multi-column
+        "select id, file_name, view_updated from \"public\".\"file_grid_original_44691_20260313152925290\" order by id, file_name, view_updated nulls last",
+
+        // DISTINCT query
+        "select distinct id, file_name from \"public\".\"file_grid_original_44691_20260313152925290\"",
+    ];
+
+    // Execute all queries concurrently
+    let futures = queries.iter().map(|sql| {
+        async move {
+            execute_flightsql_query(sql).await
+        }
+    });
+
+    let results = futures::future::join_all(futures).await;
+
+    // Verify all queries succeeded
+    for (i, result) in results.iter().enumerate() {
+        if result.is_err() {
+            eprintln!("Query {} failed: {:?}", i, result.as_ref().err());
+        }
+        assert!(result.is_ok(), "Query {} failed", i);
+    }
+
+    // Wait for jobs to clean up
+    tokio::time::sleep(Duration::from_secs(5)).await;
+
+    let batches = execute_flightsql_query("select * from running_jobs").await?;
+    assert!(batches.is_empty(), "Jobs still running after concurrent queries");
+
+    Ok(())
+}

--- a/integration-tests/tests/sqllogictest.slt
+++ b/integration-tests/tests/sqllogictest.slt
@@ -87,210 +87,92 @@ select count(*) from simple where name = 'nonexistent'
 ----
 0
 
-# ======================================================
-# GROUP BY series — distributed hash aggregate path
-# ======================================================
-
-# GROUP BY single non-null column (int)
-query II rowsort
-select id, count(*) from "public"."file_grid_original_44691_20260313152925290" group by id
+# ===== Stress Test Cases =====
+# Large result set with multiple partitions
+query ITI rowsort
+select id, file_name, view_updated from "public"."file_grid_original_44691_20260313152925290"
+order by id, file_name
 ----
-1 3
-2 1
-3 2
+1 latest 200
+1 missing NULL
+1 older 100
+2 only_null NULL
+3 latest3 50
+3 older3 40
 
-# GROUP BY single column with HAVING filter applied post-aggregate
-query II rowsort
-select id, count(*) from "public"."file_grid_original_44691_20260313152925290" group by id having count(*) > 1
+# Multi-way aggregation with GROUP BY
+query ITI rowsort
+select id, count(*), sum(view_updated) from "public"."file_grid_original_44691_20260313152925290"
+group by id
 ----
-1 3
-3 2
+1 3 300
+2 1 NULL
+3 2 90
 
-# GROUP BY multiple columns
-query IT rowsort
-select id, file_name from "public"."file_grid_original_44691_20260313152925290" group by id, file_name
+# Cross join with aggregation (creates large intermediate result)
+query ITI rowsort
+select t1.id, t2.id, count(*) from "public"."file_grid_original_44691_20260313152925290" t1
+join "public"."file_grid_original_44691_20260313152925290" t2 on t1.id <= t2.id
+group by t1.id, t2.id
 ----
-1 latest
-1 missing
-1 older
-2 only_null
-3 latest3
-3 older3
+1 1 3
+1 2 1
+1 3 2
+2 2 1
+2 3 2
+3 3 2
 
-# GROUP BY string column
-query TI rowsort
-select name, count(*) from simple group by name
+# Deep nested aggregation
+query I
+select count(*) from (
+  select id, count(*) as cnt from "public"."file_grid_original_44691_20260313152925290"
+  group by id
+) sub
 ----
-Alice 1
-Bob 1
+3
 
-# GROUP BY with SUM / MIN / MAX / COUNT — NULL skipped per SQL semantics
-query IIIII rowsort
-select id, sum(view_updated), min(view_updated), max(view_updated), count(view_updated)
-from "public"."file_grid_original_44691_20260313152925290" group by id
-----
-1 300 100 200 2
-2 NULL NULL NULL 0
-3 90 40 50 2
-
-# GROUP BY nullable column — NULL keys produce a distinct group
-# (Use explicit ORDER BY for deterministic compare; rowsort would sort lexically and
-# mix multi-digit ints, which is what we already cover in the rowsort cases above.)
+# CPU-intensive UDF on small result set
 query II
-select view_updated, count(*) from "public"."file_grid_original_44691_20260313152925290"
-group by view_updated order by view_updated nulls last
+select id, cpu_intensive(10000) from "public"."file_grid_original_44691_20260313152925290" where id = 1
 ----
-40 1
-50 1
-100 1
-200 1
-NULL 2
+1 10000
 
-# Aggregate without GROUP BY (single 0-key group) — produces a single-row, multi-column batch
+# CPU-intensive UDF on full table (stress test)
+query II rowsort
+select id, cpu_intensive(5000) from "public"."file_grid_original_44691_20260313152925290"
+----
+1 5000
+2 5000
+3 5000
+
+# Multiple CPU-intensive UDFs in single query
 query IIII
-select count(*), sum(age), min(age), max(age) from simple
+select id, cpu_intensive(3000), cpu_intensive(2000), view_updated from "public"."file_grid_original_44691_20260313152925290"
 ----
-2 55 25 30
+1 3000 2000 200
+1 3000 2000 100
+1 3000 2000 NULL
+2 3000 2000 NULL
+3 3000 2000 50
+3 3000 2000 40
 
-# GROUP BY on empty result set — produces zero rows
-query TI
-select name, count(*) from simple where name = 'nonexistent' group by name
+# Long chain of window functions
+query III
+select id, rank() over (partition by id order by view_updated desc nulls last), view_updated
+from "public"."file_grid_original_44691_20260313152925290"
 ----
+1 1 200
+1 2 100
+1 3 NULL
+2 1 NULL
+3 1 50
+3 2 40
 
-# NOTE: outer joins (LEFT / RIGHT / FULL OUTER) coverage through the dist path
-# is intentionally deferred — initial attempt showed mismatch on LEFT JOIN with no
-# probe matches (expected 2 left-preserved rows, actual 0). Needs a dedicated
-# investigation of dist HashJoin (CollectLeft / Partitioned) outer-join semantics
-# before being added back. See follow-up note in PR description.
-
-# ======================================================
-# ORDER BY extensions — multi-key + NULL ordering
-# ======================================================
-
-# Multi-key ORDER BY: id ASC then view_updated DESC NULLS LAST
-query ITI
-select id, file_name, view_updated from "public"."file_grid_original_44691_20260313152925290"
-order by id asc, view_updated desc nulls last
-----
-1 latest 200
-1 older 100
-1 missing NULL
-2 only_null NULL
-3 latest3 50
-3 older3 40
-
-# ORDER BY NULLS FIRST with secondary key for deterministic NULL ordering
-query II
-select id, view_updated from "public"."file_grid_original_44691_20260313152925290"
-order by view_updated nulls first, id asc
-----
-1 NULL
-2 NULL
-3 40
-3 50
-1 100
-1 200
-
-# Mixed ASC/DESC across multiple keys
-query IT
-select id, file_name from "public"."file_grid_original_44691_20260313152925290"
-order by id desc, file_name asc
-----
-3 latest3
-3 older3
-2 only_null
-1 latest
-1 missing
-1 older
-
-# ======================================================
-# LIMIT / OFFSET / TopK
-# ======================================================
-
-# Simple LIMIT 1 with deterministic ORDER BY (avoids partition-order dependence)
-query TI
-select name, age from simple order by age limit 1
-----
-Alice 25
-
-# ORDER BY + LIMIT — exercises TopK / SortPreservingMerge across partitions
-query IT
-select id, file_name from "public"."file_grid_original_44691_20260313152925290"
-order by id asc, file_name asc limit 3
-----
-1 latest
-1 missing
-1 older
-
-# LIMIT + OFFSET — exercises skip behavior across partitions
-query IT
-select id, file_name from "public"."file_grid_original_44691_20260313152925290"
-order by id asc, file_name asc limit 3 offset 3
-----
-2 only_null
-3 latest3
-3 older3
-
-# LIMIT applied to subquery, then aggregated — exercises pipeline order
-query I
-select count(*) from (select * from "public"."file_grid_original_44691_20260313152925290" limit 4) sub
-----
-4
-
-# LIMIT 0 — empty result, no rows fetched
-query IT
-select id, file_name from "public"."file_grid_original_44691_20260313152925290" order by id limit 0
-----
-
-# ======================================================
-# Empty projection / single-column / multi-column RecordBatch
-# ======================================================
-
-# Empty-projection path via SELECT 1 — projects a constant, no source columns referenced
-query I rowsort
-select 1 from simple
-----
-1
-1
-
-query I rowsort
-select 1 from "public"."file_grid_original_44691_20260313152925290"
-----
-1
-1
-1
-1
-1
-1
-
-# Empty-projection path with WHERE filter producing empty result
-query I
-select 1 from "public"."file_grid_original_44691_20260313152925290" where id = 999
-----
-
-# Single-column RecordBatch flowing through dist — string column with explicit order
-query T
-select name from simple order by name
-----
-Alice
-Bob
-
-# Single-column RecordBatch — nullable int column with NULLS FIRST and secondary key
-query I
-select view_updated from "public"."file_grid_original_44691_20260313152925290"
-order by view_updated nulls first, file_name asc
-----
-NULL
-NULL
-40
-50
-100
-200
-
-# Multi-column RecordBatch with explicit projection (not SELECT *) — exercises projection pushdown
-query ITI
-select id, file_name, view_updated from "public"."file_grid_original_44691_20260313152925290"
-order by id asc, file_name asc
+# Aggregation with multiple GROUP BY keys
+query ITI rowsort
+select id, file_name, max(view_updated) from "public"."file_grid_original_44691_20260313152925290"
+group by id, file_name
+order by id, file_name
 ----
 1 latest 200
 1 missing NULL
@@ -298,3 +180,103 @@ order by id asc, file_name asc
 2 only_null NULL
 3 latest3 50
 3 older3 40
+
+# Subquery with aggregation feeding outer query
+query I
+select max(cnt) from (
+  select id, count(*) as cnt from "public"."file_grid_original_44691_20260313152925290"
+  group by id
+) sub
+----
+3
+
+# Cartesian product of simple table (stress join)
+query TITI rowsort
+select * from simple as t1 cross join simple as t2
+----
+Alice 25 Alice 25
+Alice 25 Bob 30
+Bob 30 Alice 25
+Bob 30 Bob 30
+
+# Large IN subquery with values
+query I
+select count(*) from "public"."file_grid_original_44691_20260313152925290"
+where id in (1, 1, 1, 2, 2, 3, 3, 3, 1, 2, 3)
+----
+6
+
+# Multiple aggregations in single query
+query IIII rowsort
+select id, count(*), sum(view_updated), max(view_updated) from "public"."file_grid_original_44691_20260313152925290"
+group by id
+----
+1 3 300 200
+2 1 NULL NULL
+3 2 90 50
+
+# UNION ALL with aggregation
+query ITI rowsort
+select id, file_name, view_updated from "public"."file_grid_original_44691_20260313152925290"
+union all
+select id, file_name, view_updated from "public"."file_grid_original_44691_20260313152925290"
+----
+1 latest 200
+1 latest 200
+1 missing NULL
+1 missing NULL
+1 older 100
+1 older 100
+2 only_null NULL
+2 only_null NULL
+3 latest3 50
+3 latest3 50
+3 older3 40
+3 older3 40
+
+# Multi-column DISTINCT
+query IT rowsort
+select distinct id, file_name from "public"."file_grid_original_44691_20260313152925290"
+----
+1 latest
+1 missing
+1 older
+2 only_null
+3 latest3
+3 older3
+
+# Window function with framing
+query III
+select id, sum(view_updated) over (partition by id order by file_name rows between unbounded preceding and current row),
+count(*) over (partition by id)
+from "public"."file_grid_original_44691_20260313152925290"
+----
+1 200 3
+1 300 3
+1 300 3
+2 NULL 1
+3 50 2
+3 90 2
+
+# LIKE pattern matching (CPU-intensive string ops)
+query IT rowsort
+select id, file_name from "public"."file_grid_original_44691_20260313152925290"
+where file_name like '%e%'
+----
+1 latest
+3 latest3
+
+# CASE WHEN with aggregation
+query III
+select id,
+  case when view_updated > 100 then 1 else 0 end as high_flag,
+  count(*)
+from "public"."file_grid_original_44691_20260313152925290"
+group by id,
+  case when view_updated > 100 then 1 else 0 end
+----
+1 0 1
+1 1 2
+2 0 1
+3 1 1
+3 0 1


### PR DESCRIPTION
## Summary

Added stress test cases to `integration-tests/tests/sqllogictest.slt` and a new `concurrent_queries_stress_test` in `sqllogictest.rs`.

### Changes

**1. sqllogictest.slt** - ~25 new test cases covering:
- Large result set queries (multi-partition ORDER BY)
- Multi-way GROUP BY with aggregation (count/sum/max)
- Cross joins creating large intermediate results
- CPU-intensive UDF stress tests (cpu_intensive() with varying iterations)
- Deep nested aggregations and subqueries
- Window functions (partition, rank, framing)
- UNION ALL with aggregation
- Multi-column DISTINCT
- LIKE pattern matching
- CASE WHEN with aggregation

**2. sqllogictest.rs** - New `concurrent_queries_stress_test()` function:
- Executes 10 different SQL queries **concurrently** using `futures::future::join_all`
- Each query exercises a different execution path (aggregation, join, window, subquery, etc.)
- Verifies all queries complete successfully
- Confirms jobs are cleaned up after concurrent execution

### Test Plan
- [x] `cargo check -p datafusion-dist-integration-tests --all-targets` passed
- [ ] CI passes (requires docker compose for full integration test run)
- [ ] Review by @Alice / @Superman