### PR TITLE
chore: bump version to 0.4.0 (DataFusion 53)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1408,7 +1408,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-dist"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "arrow 58.3.0",
  "async-trait",
@@ -1434,7 +1434,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-dist-cluster-postgres"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "bb8",
@@ -1450,7 +1450,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-dist-integration-tests"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "arrow-flight 58.3.0",
  "async-trait",
@@ -1469,7 +1469,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-dist-integration-tests-app"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "arrow-flight 58.3.0",
  "async-trait",
@@ -1492,7 +1492,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-dist-network-tonic"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "arrow 58.3.0",
  "arrow-flight 58.3.0",
@@ -1515,7 +1515,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-dist-network-tonic-gen"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "tonic-prost-build",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,17 +10,17 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 homepage = "https://github.com/systemxlabs/datafusion-dist"
 license = "MIT"
 repository = "https://github.com/systemxlabs/datafusion-dist"
 
 [workspace.dependencies]
-datafusion-dist = { path = "dist", version = "0.3.0" }
-datafusion-dist-cluster-postgres = { path = "clusters/postgres", version = "0.3.0" }
-datafusion-dist-network-tonic = { path = "networks/tonic", version = "0.3.0" }
-datafusion-dist-integration-tests = { path = "integration-tests", version = "0.3.0" }
+datafusion-dist = { path = "dist", version = "0.4.0" }
+datafusion-dist-cluster-postgres = { path = "clusters/postgres", version = "0.4.0" }
+datafusion-dist-network-tonic = { path = "networks/tonic", version = "0.4.0" }
+datafusion-dist-integration-tests = { path = "integration-tests", version = "0.4.0" }
 
 arrow = "58"
 arrow-flight = "58"


### PR DESCRIPTION
Bump workspace version from 0.3.0 to 0.4.0.